### PR TITLE
Implement drill archiving via patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # blunderfixer-api
+
+## Archive a drill
+
+To hide a drill from your feed, send a `PATCH` request to `/drills/{id}` with
+`{"archived": true}`. The endpoint returns the updated drill information.

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -76,3 +76,9 @@ class DrillPositionResponse(BaseModel):
     history: list[DrillHistoryRead] = []
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class DrillUpdateRequest(BaseModel):
+    """Fields that can be updated on a drill."""
+
+    archived: Optional[bool] = None


### PR DESCRIPTION
## Summary
- remove the `/drills/{id}/archive` endpoint
- keep the PATCH `/drills/{id}` route to update drill fields
- document how to archive a drill using PATCH

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684065012c38832abb7d39537721deaf