### PR TITLE
Expose PGN in drill detail response

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This FastAPI service powers the chess training features of **BlunderFixer**. A r
 - `GET  /drills` – list drill positions. Supports filtering by username, eval swing, phase, opponent and more. `recent_first=true` orders by last played.
 - `GET  /drills/recent` – drills you've played recently.
 - `GET  /drills/mastered` – drills where your last five attempts were passes.
-- `GET  /drills/{id}` – retrieve a drill with game info and history.
+- `GET  /drills/{id}` – retrieve a drill with game info, history and the game's PGN.
 - `PATCH /drills/{id}` – update a drill (e.g. `{ "archived": true }` or mark as played).
 - `GET  /drills/{id}/history` – list history entries for a drill.
 - `POST /drills/{id}/history` – record a pass/fail result for a drill.

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -71,6 +71,7 @@ class DrillPositionResponse(BaseModel):
     opponent_rating: int
     game_played_at: datetime
     phase: str
+    pgn: Optional[str] = None
     archived: bool
     has_one_winning_move: bool = False
     winning_moves: Optional[list[str]] = None

--- a/app/services/drills_service.py
+++ b/app/services/drills_service.py
@@ -437,6 +437,7 @@ class DrillService:
             opponent_username=game.black_username if hero_is_white else game.white_username,
             opponent_rating=game.black_rating if hero_is_white else game.white_rating,
             game_played_at=game.played_at,
+            pgn=game.pgn,
             phase=phase,
             mastered=mastered,
             archived=drill.archived,


### PR DESCRIPTION
## Summary
- expose the game PGN in `DrillPositionResponse`
- include the PGN when returning a drill
- update README to document the PGN field

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849488079e8832a823d89c34bc0ad85