### PR TITLE
Expose features on drill details

### DIFF
--- a/app/routes/fen_feature_extraction.py
+++ b/app/routes/fen_feature_extraction.py
@@ -20,11 +20,8 @@ PIECE_NAME = {
 }
 
 
-@router.post(
-    "/extract-features", summary="Extract position features from a FEN for LLM coaching"
-)
-def extract_features(req: FeatureExtractionRequest):
-    board = chess.Board(req.fen)
+def extract_features_from_board(board: chess.Board) -> dict:
+    """Return structured positional features for a given board."""
 
     # Phase-1 & Phase-2 core features
     material = get_material_balance(board)
@@ -83,6 +80,19 @@ def extract_features(req: FeatureExtractionRequest):
     }
 
     return features
+
+
+def extract_features_from_fen(fen: str) -> dict:
+    """Helper to compute features from a FEN string."""
+    return extract_features_from_board(chess.Board(fen))
+
+
+@router.post(
+    "/extract-features", summary="Extract position features from a FEN for LLM coaching"
+)
+def extract_features(req: FeatureExtractionRequest):
+    board = chess.Board(req.fen)
+    return extract_features_from_board(board)
 
 
 def get_material_balance(board):

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -76,6 +76,7 @@ class DrillPositionResponse(BaseModel):
     has_one_winning_move: bool = False
     winning_moves: Optional[list[str]] = None
     losing_move: Optional[str] = None
+    features: Optional[Dict[str, Any]] = None
     mastered: bool
     history: list[DrillHistoryRead] = []
     last_drilled_at: Optional[datetime] = None

--- a/app/services/drills_service.py
+++ b/app/services/drills_service.py
@@ -16,6 +16,7 @@ from app.schemas import (
     DrillPositionResponse,
     DrillUpdateRequest,
 )
+from app.routes.fen_feature_extraction import extract_features_from_fen
 
 
 class DrillNotFound(Exception):
@@ -420,6 +421,8 @@ class DrillService:
         recent = history_sorted[:5]
         mastered = len(recent) == 5 and all(h.result == "pass" for h in recent)
 
+        features = extract_features_from_fen(drill.fen)
+
         return DrillPositionResponse(
             id=drill.id,
             game_id=drill.game_id,
@@ -444,6 +447,7 @@ class DrillService:
             has_one_winning_move=drill.has_one_winning_move,
             winning_moves=drill.winning_moves,
             losing_move=drill.losing_move,
+            features=features,
             history=[DrillHistoryRead.from_orm(h) for h in drill.history],
             last_drilled_at=drill.last_drilled_at,
         )


### PR DESCRIPTION
## Summary
- allow `DrillPositionResponse` to include positional features
- refactor `fen_feature_extraction` so feature logic lives in a reusable helper
- compute features when returning a single drill

## Testing
- `python -m py_compile app/routes/fen_feature_extraction.py app/services/drills_service.py app/schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_68494879d6fc832a8661aef27a217649