### PR TITLE
Add blunders fixed endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This FastAPI service powers the chess training features of **BlunderFixer**. A r
 
 ### Player statistics
 - `GET /player_stats/{username}` – aggregated stats including win rates, openings and rating progression.
+- `GET /player_stats/{username}/blunders_fixed` – total passes recorded for that user's drills.
 
 ## Contributing
 

--- a/app/routes/player_stats/index.py
+++ b/app/routes/player_stats/index.py
@@ -7,13 +7,13 @@ from sqlmodel import Session, select
 from app.db import get_session
 from app.models import DrillHistory, DrillPosition, Game
 from app.routes.player_stats.schemas import (
+    BlundersFixedResponse,
     EcoFamilyStats,
     EcoStats,
     EloProgressionEntry,
     EloSeries,
     OpponentStats,
     OverallStats,
-    BlundersFixedResponse,
     PlayerStatsResponse,
     RatingBucketStats,
     TerminationStats,
@@ -279,6 +279,6 @@ def get_blunders_fixed(
         .join(DrillPosition, DrillHistory.drill_position_id == DrillPosition.id)
         .where(DrillPosition.username == username)
         .where(DrillHistory.result == "pass")
-    ).one()[0]
+    ).one()
 
     return BlundersFixedResponse(username=username, blunders_fixed=count)

--- a/app/routes/player_stats/index.py
+++ b/app/routes/player_stats/index.py
@@ -275,7 +275,8 @@ def get_blunders_fixed(
 ) -> BlundersFixedResponse:
     count = session.exec(
         select(func.count())
-        .join(DrillPosition, DrillPosition.id == DrillHistory.drill_position_id)
+        .select_from(DrillHistory)
+        .join(DrillPosition, DrillHistory.drill_position_id == DrillPosition.id)
         .where(DrillPosition.username == username)
         .where(DrillHistory.result == "pass")
     ).one()[0]

--- a/app/routes/player_stats/schemas.py
+++ b/app/routes/player_stats/schemas.py
@@ -90,3 +90,10 @@ class PlayerStatsResponse(BaseModel):
     rating_buckets: List[RatingBucketStats] = []
     most_faced: List[OpponentStats] = []
     elo_progression: List[EloSeries] = []
+
+
+class BlundersFixedResponse(BaseModel):
+    """Total number of drills a user has passed at least once."""
+
+    username: str
+    blunders_fixed: int


### PR DESCRIPTION
## Summary
- expose new endpoint for blunders fixed count under `/player_stats`
- document the endpoint in README
- fix query to return total pass count

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bf8d569a4832a9ca8f1d9d5dc8136