### PR TITLE
Include opening info in drill responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ This FastAPI service powers the chess training features of **BlunderFixer**. A r
 - `GET  /public/players/{username}/recent-games` – fetch and normalise recent games from Chess.com.
 
 ### Drill management
-- `GET  /drills` – list drill positions. Supports filtering by username, eval swing, phase, opponent and more. `recent_first=true` orders by last played.
-- `GET  /drills/recent` – drills you've played recently.
-- `GET  /drills/mastered` – drills where your last five attempts were passes.
-- `GET  /drills/{id}` – retrieve a drill with game info, history, PGN and engine winning lines.
+- `GET  /drills` – list drill positions. Supports filtering by username, eval swing, phase, opponent and more. `recent_first=true` orders by last played. Responses include `eco`, `eco_url` and `pgn` from the game.
+- `GET  /drills/recent` – drills you've played recently. Responses include `eco`, `eco_url` and `pgn`.
+- `GET  /drills/mastered` – drills where your last five attempts were passes. Responses include `eco`, `eco_url` and `pgn`.
+- `GET  /drills/{id}` – retrieve a drill with game info, opening details (`eco`/`eco_url`), history, PGN and engine winning lines.
 - `PATCH /drills/{id}` – update a drill (e.g. `{ "archived": true }` or mark as played).
 - `GET  /drills/{id}/history` – list history entries for a drill.
 - `POST /drills/{id}/history` – record a pass/fail result (any losing moves and final eval) for a drill.

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -73,6 +73,8 @@ class DrillPositionResponse(BaseModel):
     opponent_username: str
     opponent_rating: int
     game_played_at: datetime
+    eco: Optional[str] = None
+    eco_url: Optional[str] = None
     phase: str
     pgn: Optional[str] = None
     archived: bool

--- a/app/services/drills_service.py
+++ b/app/services/drills_service.py
@@ -212,6 +212,9 @@ class DrillService:
                             game.black_rating if hero_is_white else game.white_rating
                         ),
                         game_played_at=game.played_at,
+                        eco=game.eco,
+                        eco_url=game.eco_url,
+                        pgn=game.pgn,
                         phase=phase,
                         mastered=mastered,
                         archived=dp.archived,
@@ -294,6 +297,9 @@ class DrillService:
                         game.black_rating if hero_is_white else game.white_rating
                     ),
                     game_played_at=game.played_at,
+                    eco=game.eco,
+                    eco_url=game.eco_url,
+                    pgn=game.pgn,
                     phase=classify_phase(
                         dp.ply,
                         dp.white_queen,
@@ -383,6 +389,9 @@ class DrillService:
                         game.black_rating if hero_is_white else game.white_rating
                     ),
                     game_played_at=game.played_at,
+                    eco=game.eco,
+                    eco_url=game.eco_url,
+                    pgn=game.pgn,
                     phase=classify_phase(
                         dp.ply,
                         dp.white_queen,
@@ -466,6 +475,8 @@ class DrillService:
             ),
             opponent_rating=game.black_rating if hero_is_white else game.white_rating,
             game_played_at=game.played_at,
+            eco=game.eco,
+            eco_url=game.eco_url,
             pgn=game.pgn,
             phase=phase,
             mastered=mastered,


### PR DESCRIPTION
## Summary
- add `eco`, `eco_url` and `pgn` to `DrillPositionResponse`
- return the new fields from all drill-related service methods
- document the extra fields in README

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_684c1d879084832ab45fd81396750ad6